### PR TITLE
Alex/deposit and withdraw

### DIFF
--- a/src/api/accounting.ts
+++ b/src/api/accounting.ts
@@ -1,0 +1,196 @@
+/*
+  Copyright 2018 Set Labs Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+'use strict';
+
+import * as _ from 'lodash';
+import * as Web3 from 'web3';
+import { Address } from 'set-protocol-utils';
+import { DetailedERC20Contract, VaultContract } from 'set-protocol-contracts';
+
+import { coreAPIErrors, erc20AssertionErrors, vaultAssertionErrors } from '../errors';
+import { Assertions } from '../assertions';
+import { CoreWrapper } from '../wrappers';
+import { BigNumber } from '../util';
+import { TxData } from '../types/common';
+
+/**
+ * @title SetProtocol
+ * @author Set Protocol
+ *
+ * The SetProtocol class that exposes all functionality for interacting with the SetProtocol smart contracts.
+ * Methods that require interaction with the Ethereum blockchain are exposed after instantiating a new instance
+ * of SetProtocol with the web3 provider argument
+ */
+export class AccountingAPI {
+  private web3: Web3;
+  private assert: Assertions;
+  private core: CoreWrapper;
+
+  /**
+   * Instantiates a new AccountingAPI instance that contains methods for transferring balances in the vault.
+   *
+   * @param web3                  The Web3.js Provider instance you would like the SetProtocol.js library
+   *                              to use for interacting with the Ethereum network.
+   * @param core                  The address of the Set Core contract
+   */
+  constructor(web3: Web3 = undefined, core: CoreWrapper = undefined) {
+    this.web3 = web3;
+    this.core = core;
+    this.assert = new Assertions(this.web3);
+  }
+
+  /**
+   * Deposits tokens into the vault
+   *
+   * @param  tokenAddresses[]    Addresses of contracts to withdraw (typically SetToken or ERC20)
+   * @param  quantities[]        Quantities in units of the tokens to deposit into the vault
+   * @param  txOpts              The options for executing the transaction
+   * @return                     Transaction hash
+   */
+  public async depositAsync(tokenAddresses: Address[], quantities: BigNumber[], txOpts?: TxData): Promise<string> {
+    await this.assertDeposit(
+      txOpts.from,
+      tokenAddresses,
+      quantities,
+    );
+
+    if (tokenAddresses.length === 1) {
+      return await this.core.deposit(
+        tokenAddresses[0],
+        quantities[0],
+        txOpts,
+      );
+    } else {
+      return await this.core.batchDeposit(
+        tokenAddresses,
+        quantities,
+        txOpts,
+      );
+    }
+  }
+
+  /**
+   * Withdraws tokens from the vault
+   *
+   * @param  tokenAddresses[]    Addresses of contracts to withdraw (typically SetToken or ERC20)
+   * @param  quantities[]        Quantities in units of the tokens to withdraw from the vault
+   * @param  txOpts              The options for executing the transaction
+   * @return                     Transaction hash
+   */
+  public async withdrawAsync(tokenAddresses: Address[], quantities: BigNumber[], txOpts?: TxData): Promise<string> {
+    await this.assertWithdraw(
+      txOpts.from,
+      tokenAddresses,
+      quantities,
+    );
+
+    if (tokenAddresses.length === 1) {
+      return await this.core.withdraw(
+        tokenAddresses[0],
+        quantities[0],
+        txOpts,
+      );
+    } else {
+      return await this.core.batchWithdraw(
+        tokenAddresses,
+        quantities,
+        txOpts,
+      );
+    }
+  }
+
+  /* ============ Private Assertions ============ */
+
+  private async assertDeposit(userAddress: Address, tokenAddresses: Address[], quantities: BigNumber[]) {
+    // Schema validations
+    this.assert.schema.isValidAddress('userAddress', userAddress);
+    this.assert.common.isEqualLength(
+      tokenAddresses,
+      quantities,
+      coreAPIErrors.ARRAYS_EQUAL_LENGTHS('tokenAddresses', 'quantities'),
+    );
+
+    // Quantity assertions
+    quantities.map(quantity => {
+      this.assert.common.greaterThanZero(quantity, coreAPIErrors.QUANTITY_NEEDS_TO_BE_POSITIVE(quantity));
+    });
+
+    // Token assertions
+    await Promise.all(
+      tokenAddresses.map(async (tokenAddress, i) => {
+        this.assert.common.isValidString(tokenAddress, coreAPIErrors.STRING_CANNOT_BE_EMPTY('tokenAddress'));
+        this.assert.schema.isValidAddress('tokenAddress', tokenAddress);
+
+        const tokenContract = await DetailedERC20Contract.at(tokenAddress, this.web3, {});
+        await this.assert.erc20.implementsERC20(tokenContract);
+
+        // Check balance
+        await this.assert.erc20.hasSufficientBalance(
+          tokenContract,
+          userAddress,
+          quantities[i],
+          erc20AssertionErrors.INSUFFICIENT_BALANCE(),
+        );
+
+        // Check allowance
+        await this.assert.erc20.hasSufficientAllowance(
+          tokenContract,
+          userAddress,
+          this.core.transferProxyAddress,
+          quantities[i],
+          erc20AssertionErrors.INSUFFICIENT_ALLOWANCE(),
+        );
+      }),
+    );
+  }
+
+  private async assertWithdraw(userAddress: Address, tokenAddresses: Address[], quantities: BigNumber[]) {
+    this.assert.schema.isValidAddress('userAddress', userAddress);
+    this.assert.common.isEqualLength(
+      tokenAddresses,
+      quantities,
+      coreAPIErrors.ARRAYS_EQUAL_LENGTHS('tokenAddresses', 'quantities'),
+    );
+
+    // Quantity assertions
+    _.each(quantities, quantity => {
+      this.assert.common.greaterThanZero(quantity, coreAPIErrors.QUANTITY_NEEDS_TO_BE_POSITIVE(quantity));
+    });
+
+    const vaultContract = await VaultContract.at(this.core.vaultAddress, this.web3, {});
+
+    // Token assertions
+    await Promise.all(
+      tokenAddresses.map(async (tokenAddress, i) => {
+        this.assert.common.isValidString(tokenAddress, coreAPIErrors.STRING_CANNOT_BE_EMPTY('tokenAddress'));
+        this.assert.schema.isValidAddress('tokenAddress', tokenAddress);
+
+        const detailedERC20Contract = await DetailedERC20Contract.at(tokenAddress, this.web3, {});
+        await this.assert.erc20.implementsERC20(detailedERC20Contract);
+
+        // Check balance
+        await this.assert.vault.hasSufficientTokenBalance(
+          vaultContract,
+          tokenAddress,
+          userAddress,
+          quantities[i],
+          vaultAssertionErrors.INSUFFICIENT_TOKEN_BALANCE(),
+        );
+      }),
+    );
+  }
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -17,5 +17,6 @@
 'use strict';
 
 import { OrderAPI } from './orders';
+import { AccountingAPI } from './accounting';
 
-export { OrderAPI };
+export { AccountingAPI, OrderAPI };

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -17,6 +17,7 @@
 'use strict';
 
 import { BigNumber } from '../util';
+import { DEFAULT_ACCOUNT } from '../../test/accounts';
 
 export const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
 export const ZERO: BigNumber = new BigNumber(0);
@@ -25,4 +26,10 @@ export const DEFAULT_GAS_LIMIT: BigNumber = new BigNumber(6712390); // default o
 export const UNLIMITED_ALLOWANCE_IN_BASE_UNITS: BigNumber = new BigNumber(2).pow(256).minus(1);
 export const STANDARD_TRANSFER_VALUE: BigNumber = new BigNumber(1000000000000000000); // 1 Ether
 export const STANDARD_SUPPLY: BigNumber = new BigNumber(100000000000000000000); // 100 Ether
-export const STANDARD_DECIMALS: BigNumber = new BigNumber(18); // 100 Ether
+export const STANDARD_DECIMALS: BigNumber = new BigNumber(18); // ETH natural unit, wei
+
+export const TX_DEFAULTS = {
+  from: DEFAULT_ACCOUNT,
+  gasPrice: DEFAULT_GAS_PRICE,
+  gas: DEFAULT_GAS_LIMIT,
+};

--- a/test/helpers/vaultHelpers.ts
+++ b/test/helpers/vaultHelpers.ts
@@ -16,33 +16,51 @@
 
 'use strict';
 
+import * as _ from 'lodash';
 import * as Web3 from 'web3';
-
+import { Address } from 'set-protocol-utils';
 import { Provider } from 'ethereum-types';
 import { Vault, VaultContract } from 'set-protocol-contracts';
-import { Address } from 'set-protocol-utils';
+
 import { DEFAULT_ACCOUNT } from '../accounts';
 import { VaultWrapper } from '../../src/wrappers';
-import { DEFAULT_GAS_PRICE, DEFAULT_GAS_LIMIT } from '../../src/constants';
+import { DEFAULT_GAS_PRICE, DEFAULT_GAS_LIMIT, TX_DEFAULTS } from '../../src/constants';
+import { BigNumber } from '../../src/util';
 
 const contract = require('truffle-contract');
 
-const txDefaults = {
-  from: DEFAULT_ACCOUNT,
-  gasPrice: DEFAULT_GAS_PRICE,
-  gas: DEFAULT_GAS_LIMIT,
-};
-
-export const initializeVaultWrapper = async (provider: Provider, vaultAddress: Address) => {
+export const deployVaultContract = async (provider: Provider, vaultAddress: Address): Promise<VaultContract> => {
   const vaultContract = contract(Vault);
   vaultContract.setProvider(provider);
-  vaultContract.defaults(txDefaults);
+  vaultContract.defaults(TX_DEFAULTS);
 
   // Instantiate web3
   const web3 = new Web3(provider);
 
   // Instantiate VaultWrapper
-  const vaultWrapper = await VaultContract.at(vaultAddress, web3, txDefaults);
-  const vaultAPI = new VaultWrapper(web3, vaultWrapper.address);
-  return vaultAPI;
+  return await VaultContract.at(vaultAddress, web3, TX_DEFAULTS);
+};
+
+export const initializeVaultWrapper = async (provider: Provider, vaultAddress: Address) => {
+  const vaultContract: VaultContract = await deployVaultContract(provider, vaultAddress);
+  const web3 = new Web3(provider);
+
+  return new VaultWrapper(web3, vaultContract.address);
+};
+
+export const getVaultBalances = async (
+  vault: VaultContract,
+  tokenAddresses: Address[],
+  owner: Address
+): Promise<BigNumber[]> => {
+  const balancePromises = _.map(tokenAddresses, address => {
+    return vault.getOwnerBalance.callAsync(address, owner);
+  });
+
+  let vaultBalances: BigNumber[];
+  await Promise.all(balancePromises).then(fetchedTokenBalances => {
+    vaultBalances = fetchedTokenBalances;
+  });
+
+  return vaultBalances;
 };

--- a/test/integration/VaultWrapper.spec.ts
+++ b/test/integration/VaultWrapper.spec.ts
@@ -106,7 +106,7 @@ describe('Vault API', () => {
       const token = tokenAddresses[0];
       balance = await vaultWrapper.getBalanceInVault(token, account);
       expect(balance.toNumber()).to.equal(0);
-      await coreWrapper.singleDeposit(token, new BigNumber(100), { from: account });
+      await coreWrapper.deposit(token, new BigNumber(100), { from: account });
       balance = await vaultWrapper.getBalanceInVault(token, account);
       expect(balance.toNumber()).to.equal(100);
     });

--- a/test/integration/api/accounting.spec.ts
+++ b/test/integration/api/accounting.spec.ts
@@ -1,0 +1,402 @@
+/*
+  Copyright 2018 Set Labs Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+'use strict';
+
+// Given that this is an integration test, we unmock the Set Protocol
+// smart contracts artifacts package to pull the most recently
+// deployed contracts on the current network.
+jest.unmock('set-protocol-contracts');
+jest.setTimeout(30000);
+
+import * as _ from 'lodash';
+import * as ABIDecoder from 'abi-decoder';
+import * as chai from 'chai';
+import * as ethUtil from 'ethereumjs-util';
+import * as Web3 from 'web3';
+import { Address } from 'set-protocol-utils';
+import { Core, Vault } from 'set-protocol-contracts';
+import { CoreContract, DetailedERC20Contract, StandardTokenMockContract, VaultContract } from 'set-protocol-contracts';
+
+import ChaiSetup from '../../helpers/chaiSetup';
+import { AccountingAPI } from '../../../src/api/accounting';
+import { BigNumber } from '../../../src/util';
+import { CoreWrapper } from '../../../src/wrappers';
+import { DEFAULT_ACCOUNT, ACCOUNTS } from '../../accounts';
+import { DEFAULT_GAS_PRICE, DEFAULT_GAS_LIMIT, NULL_ADDRESS, TX_DEFAULTS, ZERO } from '../../../src/constants';
+import { deployTokensForSetWithApproval, initializeCoreWrapper } from '../../helpers/coreHelpers';
+import { deployVaultContract, getVaultBalances } from '../../helpers/vaultHelpers';
+import { testSets, TestSet } from '../../testSets';
+import { Web3Utils } from '../../../src/util/Web3Utils';
+
+ChaiSetup.configure();
+const contract = require('truffle-contract');
+const provider = new Web3.providers.HttpProvider('http://localhost:8545');
+const web3 = new Web3(provider);
+const web3Utils = new Web3Utils(web3);
+const { expect } = chai;
+
+const coreContract = contract(Core);
+coreContract.setProvider(provider);
+coreContract.defaults(TX_DEFAULTS);
+
+let currentSnapshotId: number;
+
+
+describe('CoreWrapper', () => {
+  let coreWrapper: CoreWrapper;
+  let setToCreate: TestSet;
+  let tokenAddresses: Address[];
+  let vault: VaultContract;
+  let accountinAPI: AccountingAPI;
+
+  beforeAll(() => {
+    ABIDecoder.addABI(coreContract.abi);
+  });
+
+  afterAll(() => {
+    ABIDecoder.removeABI(coreContract.abi);
+  });
+
+  beforeEach(async () => {
+    currentSnapshotId = await web3Utils.saveTestSnapshot();
+
+    coreWrapper = await initializeCoreWrapper(provider);
+    setToCreate = testSets[0];
+    tokenAddresses = await deployTokensForSetWithApproval(
+      setToCreate,
+      coreWrapper.transferProxyAddress,
+      provider,
+    );
+
+    vault = await deployVaultContract(provider, coreWrapper.vaultAddress);
+    accountinAPI = new AccountingAPI(web3, coreWrapper);
+  });
+
+  afterEach(async () => {
+    await web3Utils.revertToSnapshot(currentSnapshotId);
+  });
+
+  describe('deposit', async () => {
+    let subjectTokenAddressesToDeposit: Address[];
+    let subjectQuantitiesToDeposit: BigNumber[];
+    let subjectCaller: Address;
+    let depositQuantity: BigNumber;
+
+    beforeEach(async () => {
+      depositQuantity = new BigNumber(100);
+
+      subjectTokenAddressesToDeposit = tokenAddresses;
+      subjectQuantitiesToDeposit = tokenAddresses.map(() => depositQuantity);
+      subjectCaller = DEFAULT_ACCOUNT;
+    });
+
+    async function subject(): Promise<string> {
+      return await accountinAPI.depositAsync(
+        subjectTokenAddressesToDeposit,
+        subjectQuantitiesToDeposit,
+        { from: subjectCaller },
+      );
+    }
+
+    test('correctly updates the vault balances', async () => {
+      const existingVaultOwnerBalances = await getVaultBalances(vault, tokenAddresses, subjectCaller);
+
+      await subject();
+
+      const expectedVaultOwnerBalances = _.map(existingVaultOwnerBalances, balance => balance.add(depositQuantity));
+      const newOwnerVaultBalances = await getVaultBalances(vault, tokenAddresses, subjectCaller);
+      expect(newOwnerVaultBalances).to.eql(expectedVaultOwnerBalances);
+    });
+
+    describe('when a single address and quantity is passed in', async () => {
+      let tokenAddress: Address;
+
+      beforeEach(async () => {
+        tokenAddress = tokenAddresses[0];
+
+        subjectTokenAddressesToDeposit = [tokenAddress];
+        subjectQuantitiesToDeposit = subjectTokenAddressesToDeposit.map(() => depositQuantity);
+      });
+
+      test('correctly updates the vault balance', async () => {
+        const existingOwnerVaultBalance = await vault.getOwnerBalance.callAsync(tokenAddress, DEFAULT_ACCOUNT);
+
+        await subject();
+
+        const expectedVaultOwnerBalance = existingOwnerVaultBalance.add(depositQuantity);
+        const newVaultOwnerBalance = await vault.getOwnerBalance.callAsync(tokenAddress, DEFAULT_ACCOUNT);
+        expect(newVaultOwnerBalance).to.eql(expectedVaultOwnerBalance);
+      });
+    });
+
+    describe('when the transaction caller address is invalid', async () => {
+      beforeEach(async () => {
+        subjectCaller = 'invalidAddress';
+      });
+
+      it('throws', async () => {
+        return expect(subject()).to.be.rejectedWith(
+      `
+        Expected userAddress to conform to schema /Address.
+
+        Encountered: "invalidAddress"
+
+        Validation errors: instance does not match pattern "^0x[0-9a-fA-F]{40}$"
+      `
+        );
+      });
+    });
+
+    describe('when the token addresses and quantities are not the same length', async () => {
+      beforeEach(async () => {
+        subjectTokenAddressesToDeposit = [_.first(tokenAddresses)];
+        subjectQuantitiesToDeposit = [];
+      });
+
+      it('throws', async () => {
+        return expect(subject()).to.be.rejectedWith(
+          'The tokenAddresses and quantities arrays need to be equal lengths.'
+        );
+      });
+    });
+
+    describe('when the quantities containes a negative number', async () => {
+      let invalidQuantity: BigNumber;
+
+      beforeEach(async () => {
+        invalidQuantity = new BigNumber(-1);
+
+        subjectTokenAddressesToDeposit = [_.first(tokenAddresses)];
+        subjectQuantitiesToDeposit = [invalidQuantity];
+      });
+
+      it('throws', async () => {
+        return expect(subject()).to.be.rejectedWith(
+          `The quantity ${invalidQuantity} inputted needs to be greater than zero.`
+        );
+      });
+    });
+
+    describe('when the token addresses contains an empty address', async () => {
+      beforeEach(async () => {
+        subjectTokenAddressesToDeposit = [undefined];
+        subjectQuantitiesToDeposit = [depositQuantity];
+      });
+
+      it('throws', async () => {
+        return expect(subject()).to.be.rejectedWith('The string tokenAddress cannot be empty.');
+      });
+    });
+
+    describe('when the token addresses contains an address for a contract that is not ERC20', async () => {
+      let nonERC20ContractAddress: Address;
+
+      beforeEach(async () => {
+        nonERC20ContractAddress = coreWrapper.vaultAddress;
+
+        subjectTokenAddressesToDeposit = [nonERC20ContractAddress];
+        subjectQuantitiesToDeposit = [depositQuantity];
+      });
+
+      it('throws', async () => {
+        return expect(subject()).to.be.rejectedWith(
+          `Contract at ${nonERC20ContractAddress} does not implement ERC20 interface.`
+        );
+      });
+    });
+
+    describe('when the caller does not have enough balance of token', async () => {
+      beforeEach(async () => {
+        subjectCaller = ACCOUNTS[1].address;
+      });
+
+      it('throws', async () => {
+        return expect(subject()).to.be.rejectedWith('User does not have enough balance.');
+      });
+    });
+
+    describe('when the caller has not granted enough allowance to the transfer proxy', async () => {
+      beforeEach(async () => {
+        const tokenAddress = tokenAddresses[0];
+        const tokenWrapper = await StandardTokenMockContract.at(tokenAddress, web3, TX_DEFAULTS);
+        await tokenWrapper.approve.sendTransactionAsync(
+          coreWrapper.transferProxyAddress,
+          depositQuantity.sub(1),
+          TX_DEFAULTS,
+        );
+      });
+
+      it('throws', async () => {
+        return expect(subject()).to.be.rejectedWith('User not approved for enough allowance.');
+      });
+    });
+  });
+
+  describe('withdraw', async () => {
+    let subjectTokenAddressesToWithdraw: Address[];
+    let subjectQuantitiesToWithdraw: BigNumber[];
+    let subjectCaller: Address;
+    let withdrawQuantity: BigNumber;
+
+    beforeEach(async () => {
+      withdrawQuantity = new BigNumber(100);
+
+      const quantitiesToDeposit = tokenAddresses.map(() => withdrawQuantity);
+      await accountinAPI.depositAsync(
+        tokenAddresses,
+        quantitiesToDeposit,
+        { from: DEFAULT_ACCOUNT },
+      );
+
+      subjectTokenAddressesToWithdraw = tokenAddresses;
+      subjectQuantitiesToWithdraw = quantitiesToDeposit;
+      subjectCaller = DEFAULT_ACCOUNT;
+    });
+
+    async function subject(): Promise<string> {
+      return await accountinAPI.withdrawAsync(
+        subjectTokenAddressesToWithdraw,
+        subjectQuantitiesToWithdraw,
+        { from: subjectCaller },
+      );
+    }
+
+    test('correctly updates the vault balances', async () => {
+      const existingVaultOwnerBalances = await getVaultBalances(vault, tokenAddresses, subjectCaller);
+
+      await subject();
+
+      const expectedVaultOwnerBalances = _.map(existingVaultOwnerBalances, balance => balance.sub(withdrawQuantity));
+      const newOwnerVaultBalances = await getVaultBalances(vault, tokenAddresses, subjectCaller);
+      expect(newOwnerVaultBalances).to.eql(expectedVaultOwnerBalances);
+    });
+
+    describe('when a single address and quantity is passed in', async () => {
+      let tokenAddress: Address;
+
+      beforeEach(async () => {
+        tokenAddress = tokenAddresses[0];
+
+        subjectTokenAddressesToWithdraw = [tokenAddress];
+        subjectQuantitiesToWithdraw = subjectTokenAddressesToWithdraw.map(() => withdrawQuantity);
+      });
+
+      test('correctly updates the vault balance', async () => {
+        const existingOwnerVaultBalance = await vault.getOwnerBalance.callAsync(tokenAddress, DEFAULT_ACCOUNT);
+
+        await subject();
+
+        const expectedVaultOwnerBalance = existingOwnerVaultBalance.sub(withdrawQuantity);
+        const newVaultOwnerBalance = await vault.getOwnerBalance.callAsync(tokenAddress, DEFAULT_ACCOUNT);
+        expect(newVaultOwnerBalance).to.eql(expectedVaultOwnerBalance);
+      });
+    });
+
+    describe('when the transaction caller address is invalid', async () => {
+      beforeEach(async () => {
+        subjectCaller = 'invalidAddress';
+      });
+
+      it('throws', async () => {
+        return expect(subject()).to.be.rejectedWith(
+      `
+        Expected userAddress to conform to schema /Address.
+
+        Encountered: "invalidAddress"
+
+        Validation errors: instance does not match pattern "^0x[0-9a-fA-F]{40}$"
+      `
+        );
+      });
+    });
+
+    describe('when the token addresses and quantities are not the same length', async () => {
+      beforeEach(async () => {
+        subjectTokenAddressesToWithdraw = [_.first(tokenAddresses)];
+        subjectQuantitiesToWithdraw = [];
+      });
+
+      it('throws', async () => {
+        return expect(subject()).to.be.rejectedWith(
+          'The tokenAddresses and quantities arrays need to be equal lengths.'
+        );
+      });
+    });
+
+    describe('when the quantities containes a negative number', async () => {
+      let invalidQuantity: BigNumber;
+
+      beforeEach(async () => {
+        invalidQuantity = new BigNumber(-1);
+
+        subjectTokenAddressesToWithdraw = [_.first(tokenAddresses)];
+        subjectQuantitiesToWithdraw = [invalidQuantity];
+      });
+
+      it('throws', async () => {
+        return expect(subject()).to.be.rejectedWith(
+          `The quantity ${invalidQuantity} inputted needs to be greater than zero.`
+        );
+      });
+    });
+
+    describe('when the token addresses contains an empty address', async () => {
+      beforeEach(async () => {
+        subjectTokenAddressesToWithdraw = [undefined];
+        subjectQuantitiesToWithdraw = [withdrawQuantity];
+      });
+
+      it('throws', async () => {
+        return expect(subject()).to.be.rejectedWith('The string tokenAddress cannot be empty.');
+      });
+    });
+
+    describe('when the token addresses contains an address for a contract that is not ERC20', async () => {
+      let nonERC20ContractAddress: Address;
+
+      beforeEach(async () => {
+        nonERC20ContractAddress = coreWrapper.vaultAddress;
+
+        subjectTokenAddressesToWithdraw = [nonERC20ContractAddress];
+        subjectQuantitiesToWithdraw = [withdrawQuantity];
+      });
+
+      it('throws', async () => {
+        return expect(subject()).to.be.rejectedWith(
+          `Contract at ${nonERC20ContractAddress} does not implement ERC20 interface.`
+        );
+      });
+    });
+
+    describe('when the caller does not have enough balance to withdraw', async () => {
+      beforeEach(async () => {
+        const tokenToWithdrawFromOriginallyDepositedAmount = tokenAddresses[0];
+        const quantityToWithdrawFromOringallyDepositedAmount = new BigNumber(1);
+
+        await accountinAPI.withdrawAsync(
+          [tokenToWithdrawFromOriginallyDepositedAmount],
+          [quantityToWithdrawFromOringallyDepositedAmount],
+          { from: subjectCaller },
+        );
+      });
+
+      it('throws', async () => {
+        return expect(subject()).to.be.rejectedWith('User does not have enough balance of the token in vault.');
+      });
+    });
+  });
+});


### PR DESCRIPTION
Moved deposit and withdraw, and their assertions into AccountingAPI class. It includes a full test suite including the assertions and expected throw messages. This also includes a bit of clean up including:

- Creating a constant for TX_DEFAULTS
- Adding some helpers to vaultHelper including fetching multiple token balances and initializing an instance of the contract

Going forward, we should push all initialization of contract and wrappers into helpers: see `deployVaultContract` in VaultHelper.