### PR TITLE
Chain: Add set-chain command

### DIFF
--- a/bin/chain
+++ b/bin/chain
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+const exec = require('child_process').exec;
+const chainProcess = exec('yarn chain');
+
+chainProcess.stdout.pipe(process.stdout);
+chainProcess.stderr.pipe(process.stderr);

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   ],
   "main": "dist/src/index.js",
   "typings": "dist/types/src/index.d.ts",
+  "bin": {
+    "set-chain": "bin/chain"
+  },
   "scripts": {
     "prod": "yarn run build",
     "clean-chain": "rm -rf blockchain && cp -r snapshots/0x blockchain",


### PR DESCRIPTION
Allows user to run a local TestRPC by installing `setprotocol.js` and running `set-chain` in their project.

![set-chain](https://user-images.githubusercontent.com/4149515/44942642-8d634800-ad6b-11e8-89eb-ad1fa90c6286.gif)

Projects will have to add a script in their `package.json` that looks like this after running `yarn add setprotocol.js`:
```
"scripts": {
  "set-chain": "set-chain"
}
```

Additional resources about local `.bin` commands here: https://blog.npmjs.org/post/118810260230/building-a-simple-command-line-tool-with-npm