### PR TITLE
`set-chain` command update

### DIFF
--- a/bin/chain
+++ b/bin/chain
@@ -1,6 +1,13 @@
 #!/usr/bin/env node
-const exec = require('child_process').exec;
-const chainProcess = exec('yarn chain');
+var fs = require('fs');
+var path = require('path');
+
+var localInitChain = require.resolve(path.join(process.cwd(), "node_modules", "setprotocol.js", "scripts", "init_chain.sh"));
+
+fs.chmodSync(localInitChain, 0777);
+
+var exec = require('child_process').exec;
+var chainProcess = exec(localInitChain);
 
 chainProcess.stdout.pipe(process.stdout);
 chainProcess.stderr.pipe(process.stderr);


### PR DESCRIPTION
Updates `set-chain` command to work from cwd. Previous version of `set-chain` ran `yarn chain` from the cwd of the parent repository, instead of the `setprotocol.js` package.

Update finds path to the `setprotocol.js` package, `chmod`s to allow running a shell script, then runs the `init_chain.sh` file.