### PR TITLE
CircleCI: Reduce sleep timer and add tslint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,10 @@ jobs:
               paths:
                 - node_modules
         - run: yarn build
+        - run: yarn tslint
         - run:
             name: testrpc
             command: yarn chain
             background: true
-        - run: sleep 90
+        - run: sleep 20
         - run: yarn test


### PR DESCRIPTION
# Changelog
- Increases speed of tests on CircleCI.
  - Reduces sleep timer now that contract migrations are removed from `yarn chain`.
- Adds tslint

**Notes**: Sleep timer can possibly be reduced even further. Local run time tests of `yarn chain` found an average time of `4.882` seconds out of `5` runs that resulted in run times of:
- 6.22 secs
- 5.02 secs
- 4.76 secs
- 4.12 secs
- 4.29 secs