### PR TITLE
Add Taker Wallet Order isComponent Assertion

### DIFF
--- a/src/api/OrderAPI.ts
+++ b/src/api/OrderAPI.ts
@@ -284,6 +284,7 @@ export class OrderAPI {
     this.assert.common.isNotEmptyArray(orders, coreAPIErrors.EMPTY_ARRAY('orders'));
 
     await this.assert.order.isValidZeroExOrderFills(signedIssuanceOrder, quantityToFill, orders);
+    await this.assert.order.isValidTakerWalletOrderFills(signedIssuanceOrder, quantityToFill, orders);
 
     await this.assert.order.isIssuanceOrderFillable(
       this.core.coreAddress,

--- a/src/assertions/OrderAssertions.ts
+++ b/src/assertions/OrderAssertions.ts
@@ -198,6 +198,30 @@ export class OrderAssertions {
     );
   }
 
+  public async isValidTakerWalletOrderFills (
+    signedIssuanceOrder: SignedIssuanceOrder,
+    quantityToFill: BigNumber,
+    orders: (TakerWalletOrder | ZeroExSignedFillOrder)[],
+  ) {
+    await Promise.all(
+      _.map(orders, async (order: any) => {
+        if (SetProtocolUtils.isTakerWalletOrder(order)) {
+
+          this.commonAssertions.greaterThanZero(
+            order.takerTokenAmount,
+            coreAPIErrors.QUANTITY_NEEDS_TO_BE_POSITIVE(order.takerTokenAmount),
+          );
+
+          // The taker wallet Taker token is a component of the set
+          await this.setTokenAssertions.isComponent(
+            signedIssuanceOrder.setAddress,
+            order.takerTokenAddress,
+          );
+        }
+      })
+    );
+  }
+
   public async isValidFillQuantity(
     coreContract: CoreContract,
     issuanceOrder: IssuanceOrder,

--- a/test/integration/api/OrderAPI.spec.ts
+++ b/test/integration/api/OrderAPI.spec.ts
@@ -877,6 +877,23 @@ describe('OrderAPI', () => {
         );
       });
     });
+
+    describe('when the taker wallet order taker asset is not a component of the Set', async () => {
+      let nonComponentToken: StandardTokenMockContract;
+
+      beforeEach(async () => {
+        nonComponentToken = await deployTokenAsync(provider, issuanceOrderMaker);
+        takerWalletOrder.takerTokenAddress = nonComponentToken.address;
+        subjectOrders[0] = takerWalletOrder;
+      });
+
+      test('throws', async () => {
+        return expect(subject()).to.be.rejectedWith(
+          `Token address at ${nonComponentToken.address} is not a component ` +
+          `of the Set Token at ${subjectSignedIssuanceOrder.setAddress}.`
+        );
+      });
+    });
   });
 
   describe('cancelOrderAsync', async () => {


### PR DESCRIPTION
This PR completes the following card:
https://trello.com/c/p6He3eK9/423-0x-takerwallet-order-component-inclusion-validations

In a future PR, I'll dry up the code and add an extra layer of abstraction for validating orders.