### PR TITLE
Dry up order assertions

### DIFF
--- a/src/api/OrderAPI.ts
+++ b/src/api/OrderAPI.ts
@@ -283,8 +283,7 @@ export class OrderAPI {
     this.assert.common.greaterThanZero(quantityToFill, coreAPIErrors.QUANTITY_NEEDS_TO_BE_POSITIVE(quantityToFill));
     this.assert.common.isNotEmptyArray(orders, coreAPIErrors.EMPTY_ARRAY('orders'));
 
-    await this.assert.order.isValidZeroExOrderFills(signedIssuanceOrder, quantityToFill, orders);
-    await this.assert.order.isValidTakerWalletOrderFills(signedIssuanceOrder, quantityToFill, orders);
+    await this.assert.order.assertLiquidityOrders(signedIssuanceOrder, quantityToFill, orders);
 
     await this.assert.order.isIssuanceOrderFillable(
       this.core.coreAddress,


### PR DESCRIPTION
Create `assertLiquidityOrders` function which loops through orders and checks validity of each order based on order type.