### PR TITLE
Set up Path Alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,8 @@
       "node"
     ],
     "moduleNameMapper": {
-      "^@src/(.*)": "<rootDir>/src/$1"
+      "^@src/(.*)": "<rootDir>/src/$1",
+      "^@helpers/(.*)": "<rootDir>/test/helpers/$2"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -111,6 +111,9 @@
       "jsx",
       "json",
       "node"
-    ]
+    ],
+    "moduleNameMapper": {
+      "^@src/(.*)": "<rootDir>/src/$1"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     ],
     "moduleNameMapper": {
       "^@src/(.*)": "<rootDir>/src/$1",
-      "^@helpers/(.*)": "<rootDir>/test/helpers/$2"
+      "^@helpers/(.*)": "<rootDir>/test/helpers/$1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     ],
     "moduleNameMapper": {
       "^@src/(.*)": "<rootDir>/src/$1",
-      "^@helpers/(.*)": "<rootDir>/test/helpers/$1"
+      "^@test/(.*)": "<rootDir>/test/$1"
     }
   }
 }

--- a/test/helpers/coreHelpers.ts
+++ b/test/helpers/coreHelpers.ts
@@ -30,9 +30,9 @@ import {
   DEPLOYED_TOKEN_QUANTITY,
   TX_DEFAULTS,
   UNLIMITED_ALLOWANCE_IN_BASE_UNITS
-} from '../../src/constants';
-import { BigNumber, getFormattedLogsFromTxHash, extractNewSetTokenAddressFromLogs } from '../../src/util';
-import { CoreWrapper } from '../../src/wrappers';
+} from '@src/constants';
+import { BigNumber, getFormattedLogsFromTxHash, extractNewSetTokenAddressFromLogs } from '@src/util';
+import { CoreWrapper } from '@src/wrappers';
 
 const contract = require('truffle-contract');
 

--- a/test/helpers/exchangeHelpers.ts
+++ b/test/helpers/exchangeHelpers.ts
@@ -12,9 +12,9 @@ import {
   ZeroExExchangeWrapperContract,
 } from 'set-protocol-contracts';
 import { Address, SetProtocolUtils } from 'set-protocol-utils';
-import { BigNumber } from '../../src/util';
-import { DEFAULT_ACCOUNT } from '../../src/constants/accounts';
-import { TX_DEFAULTS } from '../../src/constants';
+import { BigNumber } from '@src/util';
+import { DEFAULT_ACCOUNT } from '@src/constants/accounts';
+import { TX_DEFAULTS } from '@src/constants';
 
 const contract = require('truffle-contract');
 

--- a/test/helpers/vaultHelpers.ts
+++ b/test/helpers/vaultHelpers.ts
@@ -22,10 +22,10 @@ import { Address, SetProtocolUtils } from 'set-protocol-utils';
 import { Provider } from 'ethereum-types';
 import { Vault, VaultContract } from 'set-protocol-contracts';
 
-import { DEFAULT_ACCOUNT } from '../../src/constants/accounts';
-import { VaultWrapper } from '../../src/wrappers';
-import { DEFAULT_GAS_PRICE, DEFAULT_GAS_LIMIT, TX_DEFAULTS } from '../../src/constants';
-import { BigNumber } from '../../src/util';
+import { DEFAULT_ACCOUNT } from '@src/constants/accounts';
+import { VaultWrapper } from '@src/wrappers';
+import { DEFAULT_GAS_PRICE, DEFAULT_GAS_LIMIT, TX_DEFAULTS } from '@src/constants';
+import { BigNumber } from '@src/util';
 
 const contract = require('truffle-contract');
 

--- a/test/integration/CoreWrapper.spec.ts
+++ b/test/integration/CoreWrapper.spec.ts
@@ -37,9 +37,9 @@ import {
   ZeroExSignedFillOrder,
 } from 'set-protocol-utils';
 
-import { DEFAULT_ACCOUNT, ACCOUNTS } from '../../src/constants/accounts';
-import { CoreWrapper } from '../../src/wrappers';
-import { OrderAPI } from '../../src/api';
+import { DEFAULT_ACCOUNT, ACCOUNTS } from '@src/constants/accounts';
+import { CoreWrapper } from '@src/wrappers';
+import { OrderAPI } from '@src/api';
 import {
   CoreContract,
   SetTokenContract,
@@ -49,8 +49,8 @@ import {
   VaultContract,
   ZeroExExchangeWrapperContract,
 } from 'set-protocol-contracts';
-import { NULL_ADDRESS, TX_DEFAULTS, ZERO } from '../../src/constants';
-import { Assertions } from '../../src/assertions';
+import { NULL_ADDRESS, TX_DEFAULTS, ZERO } from '@src/constants';
+import { Assertions } from '@src/assertions';
 import {
   addAuthorizationAsync,
   approveForTransferAsync,
@@ -72,7 +72,7 @@ import {
   generateFutureTimestamp,
   getFormattedLogsFromTxHash,
   Web3Utils
-} from '../../src/util';
+} from '@src/util';
 
 const chaiBigNumber = require('chai-bignumber');
 chai.use(chaiBigNumber(BigNumber));

--- a/test/integration/CoreWrapper.spec.ts
+++ b/test/integration/CoreWrapper.spec.ts
@@ -64,7 +64,7 @@ import {
   deployTakerWalletWrapperContract,
   deployZeroExExchangeWrapperContract,
   getVaultBalances,
-} from '../helpers';
+} from '@helpers/index';
 import {
   BigNumber,
   ether,

--- a/test/integration/CoreWrapper.spec.ts
+++ b/test/integration/CoreWrapper.spec.ts
@@ -64,7 +64,7 @@ import {
   deployTakerWalletWrapperContract,
   deployZeroExExchangeWrapperContract,
   getVaultBalances,
-} from '@helpers/index';
+} from '@test/helpers';
 import {
   BigNumber,
   ether,

--- a/test/integration/ERC20Wrapper.spec.ts
+++ b/test/integration/ERC20Wrapper.spec.ts
@@ -33,7 +33,7 @@ import { DEFAULT_ACCOUNT, DEPLOYED_TOKEN_QUANTITY, TX_DEFAULTS } from '@src/cons
 import { ACCOUNTS } from '@src/constants/accounts';
 import { BigNumber, Web3Utils } from '@src/util';
 import { ether } from '@src/util/units';
-import { addAuthorizationAsync, deployTokenAsync } from '../helpers';
+import { addAuthorizationAsync, deployTokenAsync } from '@test/helpers';
 
 const chaiBigNumber = require('chai-bignumber');
 chai.use(chaiBigNumber(BigNumber));

--- a/test/integration/ERC20Wrapper.spec.ts
+++ b/test/integration/ERC20Wrapper.spec.ts
@@ -28,11 +28,11 @@ import { StandardTokenMock } from 'set-protocol-contracts';
 import { StandardTokenMockContract } from 'set-protocol-contracts';
 import { Address } from 'set-protocol-utils';
 
-import { ERC20Wrapper } from '../../src/wrappers';
-import { DEFAULT_ACCOUNT, DEPLOYED_TOKEN_QUANTITY, TX_DEFAULTS } from '../../src/constants';
-import { ACCOUNTS } from '../../src/constants/accounts';
-import { BigNumber, Web3Utils } from '../../src/util';
-import { ether } from '../../src/util/units';
+import { ERC20Wrapper } from '@src/wrappers';
+import { DEFAULT_ACCOUNT, DEPLOYED_TOKEN_QUANTITY, TX_DEFAULTS } from '@src/constants';
+import { ACCOUNTS } from '@src/constants/accounts';
+import { BigNumber, Web3Utils } from '@src/util';
+import { ether } from '@src/util/units';
 import { addAuthorizationAsync, deployTokenAsync } from '../helpers';
 
 const chaiBigNumber = require('chai-bignumber');

--- a/test/integration/SetProtocol.spec.ts
+++ b/test/integration/SetProtocol.spec.ts
@@ -58,7 +58,7 @@ import {
   deployTokensAsync,
   deployTransferProxyContract,
   deployVaultContract,
-} from '../helpers';
+} from '@test/helpers';
 import { ether } from '@src/util/units';
 
 ChaiSetup.configure();

--- a/test/integration/SetProtocol.spec.ts
+++ b/test/integration/SetProtocol.spec.ts
@@ -40,14 +40,14 @@ import {
 import { Address, SetProtocolUtils } from 'set-protocol-utils';
 
 import ChaiSetup from '../helpers/chaiSetup';
-import { DEFAULT_ACCOUNT } from '../../src/constants/accounts';
-import SetProtocol from '../../src/SetProtocol';
-import { DEFAULT_GAS_PRICE, DEFAULT_GAS_LIMIT, NULL_ADDRESS, TX_DEFAULTS } from '../../src/constants';
-import { Web3Utils } from '../../src/util/Web3Utils';
-import { getFormattedLogsFromTxHash, extractNewSetTokenAddressFromLogs } from '../../src/util/logs';
-import { BigNumber } from '../../src/util';
-import { SetProtocolConfig } from '../../src/SetProtocol';
-import { ERC20Wrapper } from '../../src/wrappers/ERC20Wrapper';
+import { DEFAULT_ACCOUNT } from '@src/constants/accounts';
+import SetProtocol from '@src/SetProtocol';
+import { DEFAULT_GAS_PRICE, DEFAULT_GAS_LIMIT, NULL_ADDRESS, TX_DEFAULTS } from '@src/constants';
+import { Web3Utils } from '@src/util/Web3Utils';
+import { getFormattedLogsFromTxHash, extractNewSetTokenAddressFromLogs } from '@src/util/logs';
+import { BigNumber } from '@src/util';
+import { SetProtocolConfig } from '@src/SetProtocol';
+import { ERC20Wrapper } from '@src/wrappers/ERC20Wrapper';
 import {
   addAuthorizationAsync,
   approveForTransferAsync,
@@ -59,7 +59,7 @@ import {
   deployTransferProxyContract,
   deployVaultContract,
 } from '../helpers';
-import { ether } from '../../src/util/units';
+import { ether } from '@src/util/units';
 
 ChaiSetup.configure();
 const { expect } = chai;

--- a/test/integration/SetTokenWrapper.spec.ts
+++ b/test/integration/SetTokenWrapper.spec.ts
@@ -34,10 +34,10 @@ import {
 } from 'set-protocol-contracts';
 import { Address } from 'set-protocol-utils';
 
-import { CoreWrapper, SetTokenWrapper } from '../../src/wrappers';
-import { DEFAULT_ACCOUNT, TX_DEFAULTS } from '../../src/constants';
-import { BigNumber, Web3Utils } from '../../src/util';
-import { ether } from '../../src/util/units';
+import { CoreWrapper, SetTokenWrapper } from '@src/wrappers';
+import { DEFAULT_ACCOUNT, TX_DEFAULTS } from '@src/constants';
+import { BigNumber, Web3Utils } from '@src/util';
+import { ether } from '@src/util/units';
 import {
   addAuthorizationAsync,
   approveForTransferAsync,

--- a/test/integration/SetTokenWrapper.spec.ts
+++ b/test/integration/SetTokenWrapper.spec.ts
@@ -47,7 +47,7 @@ import {
   deployVaultContract,
   deployTokensAsync,
   deployTransferProxyContract
-} from '../helpers';
+} from '@test/helpers';
 
 const chaiBigNumber = require('chai-bignumber');
 chai.use(chaiBigNumber(BigNumber));

--- a/test/integration/VaultWrapper.spec.ts
+++ b/test/integration/VaultWrapper.spec.ts
@@ -32,9 +32,9 @@ import {
 } from 'set-protocol-contracts';
 import { Address } from 'set-protocol-utils';
 
-import { CoreWrapper, VaultWrapper } from '../../src/wrappers';
-import { DEFAULT_ACCOUNT, TX_DEFAULTS } from '../../src/constants';
-import { BigNumber, Web3Utils } from '../../src/util';
+import { CoreWrapper, VaultWrapper } from '@src/wrappers';
+import { DEFAULT_ACCOUNT, TX_DEFAULTS } from '@src/constants';
+import { BigNumber, Web3Utils } from '@src/util';
 import {
   addAuthorizationAsync,
   approveForTransferAsync,

--- a/test/integration/VaultWrapper.spec.ts
+++ b/test/integration/VaultWrapper.spec.ts
@@ -42,7 +42,7 @@ import {
   deployVaultContract,
   deployTokenAsync,
   deployTransferProxyContract
-} from '../helpers';
+} from '@test/helpers';
 
 const chaiBigNumber = require('chai-bignumber');
 chai.use(chaiBigNumber(BigNumber));

--- a/test/integration/api/AccountingAPI.spec.ts
+++ b/test/integration/api/AccountingAPI.spec.ts
@@ -30,13 +30,13 @@ import { Address } from 'set-protocol-utils';
 import { Core } from 'set-protocol-contracts';
 import { CoreContract, StandardTokenMockContract, TransferProxyContract, VaultContract } from 'set-protocol-contracts';
 
-import ChaiSetup from '../../helpers/chaiSetup';
-import { AccountingAPI } from '../../../src/api';
-import { BigNumber } from '../../../src/util';
-import { Assertions } from '../../../src/assertions';
-import { CoreWrapper } from '../../../src/wrappers';
-import { DEFAULT_ACCOUNT, ACCOUNTS } from '../../../src/constants/accounts';
-import { TX_DEFAULTS, ZERO } from '../../../src/constants';
+import ChaiSetup from '@helpers/chaiSetup';
+import { AccountingAPI } from '@src/api';
+import { BigNumber } from '@src/util';
+import { Assertions } from '@src/assertions';
+import { CoreWrapper } from '@src/wrappers';
+import { DEFAULT_ACCOUNT, ACCOUNTS } from '@src/constants/accounts';
+import { TX_DEFAULTS, ZERO } from '@src/constants';
 import {
   addAuthorizationAsync,
   approveForTransferAsync,
@@ -45,9 +45,9 @@ import {
   deployTransferProxyContract,
   deployVaultContract,
   getVaultBalances
-} from '../../helpers';
+} from '@helpers/index';
 import { testSets, TestSet } from '../../testSets';
-import { Web3Utils } from '../../../src/util/Web3Utils';
+import { Web3Utils } from '@src/util/Web3Utils';
 
 ChaiSetup.configure();
 const contract = require('truffle-contract');

--- a/test/integration/api/AccountingAPI.spec.ts
+++ b/test/integration/api/AccountingAPI.spec.ts
@@ -30,7 +30,7 @@ import { Address } from 'set-protocol-utils';
 import { Core } from 'set-protocol-contracts';
 import { CoreContract, StandardTokenMockContract, TransferProxyContract, VaultContract } from 'set-protocol-contracts';
 
-import ChaiSetup from '@helpers/chaiSetup';
+import ChaiSetup from '@test/helpers/chaiSetup';
 import { AccountingAPI } from '@src/api';
 import { BigNumber } from '@src/util';
 import { Assertions } from '@src/assertions';
@@ -45,7 +45,7 @@ import {
   deployTransferProxyContract,
   deployVaultContract,
   getVaultBalances
-} from '@helpers/index';
+} from '@test/helpers';
 import { testSets, TestSet } from '../../testSets';
 import { Web3Utils } from '@src/util/Web3Utils';
 

--- a/test/integration/api/BlockchainAPI.spec.ts
+++ b/test/integration/api/BlockchainAPI.spec.ts
@@ -32,7 +32,7 @@ import { Address, Log } from 'set-protocol-utils';
 import { StandardTokenMock } from 'set-protocol-contracts';
 import { CoreContract, StandardTokenMockContract, VaultContract } from 'set-protocol-contracts';
 
-import ChaiSetup from '@helpers/chaiSetup';
+import ChaiSetup from '@test/helpers/chaiSetup';
 import { BlockchainAPI } from '@src/api';
 import { CoreWrapper } from '@src/wrappers';
 import { Assertions } from '@src/assertions';
@@ -44,8 +44,8 @@ import {
   deployVaultContract,
   deployTransferProxyContract,
   deployCoreContract
-} from '@helpers/index';
-import { getVaultBalances } from '@helpers/vaultHelpers';
+} from '@test/helpers';
+import { getVaultBalances } from '@test/helpers/vaultHelpers';
 import { testSets, TestSet } from '../../testSets';
 import { Web3Utils } from '@src/util/Web3Utils';
 

--- a/test/integration/api/BlockchainAPI.spec.ts
+++ b/test/integration/api/BlockchainAPI.spec.ts
@@ -32,22 +32,22 @@ import { Address, Log } from 'set-protocol-utils';
 import { StandardTokenMock } from 'set-protocol-contracts';
 import { CoreContract, StandardTokenMockContract, VaultContract } from 'set-protocol-contracts';
 
-import ChaiSetup from '../../helpers/chaiSetup';
-import { BlockchainAPI } from '../../../src/api';
-import { CoreWrapper } from '../../../src/wrappers';
-import { Assertions } from '../../../src/assertions';
-import { BigNumber, getFormattedLogsFromReceipt } from '../../../src/util';
-import { DEFAULT_ACCOUNT, ACCOUNTS } from '../../../src/constants/accounts';
-import { TX_DEFAULTS, ZERO } from '../../../src/constants';
+import ChaiSetup from '@helpers/chaiSetup';
+import { BlockchainAPI } from '@src/api';
+import { CoreWrapper } from '@src/wrappers';
+import { Assertions } from '@src/assertions';
+import { BigNumber, getFormattedLogsFromReceipt } from '@src/util';
+import { DEFAULT_ACCOUNT, ACCOUNTS } from '@src/constants/accounts';
+import { TX_DEFAULTS, ZERO } from '@src/constants';
 import {
   deployTokenAsync,
   deployVaultContract,
   deployTransferProxyContract,
   deployCoreContract
-} from '../../helpers';
-import { getVaultBalances } from '../../helpers/vaultHelpers';
+} from '@helpers/index';
+import { getVaultBalances } from '@helpers/vaultHelpers';
 import { testSets, TestSet } from '../../testSets';
-import { Web3Utils } from '../../../src/util/Web3Utils';
+import { Web3Utils } from '@src/util/Web3Utils';
 
 ChaiSetup.configure();
 const contract = require('truffle-contract');

--- a/test/integration/api/ERC20API.spec.ts
+++ b/test/integration/api/ERC20API.spec.ts
@@ -28,20 +28,20 @@ import { StandardTokenMock } from 'set-protocol-contracts';
 import { StandardTokenMockContract } from 'set-protocol-contracts';
 import { Address } from 'set-protocol-utils';
 
-import ChaiSetup from '../../helpers/chaiSetup';
-import { CoreWrapper } from '../../../src/wrappers';
-import { Assertions } from '../../../src/assertions';
-import { ERC20API } from '../../../src/api';
-import { DEFAULT_ACCOUNT, DEPLOYED_TOKEN_QUANTITY, TX_DEFAULTS } from '../../../src/constants';
-import { ACCOUNTS } from '../../../src/constants/accounts';
-import { BigNumber, ether, Web3Utils } from '../../../src/util';
+import ChaiSetup from '@helpers/chaiSetup';
+import { CoreWrapper } from '@src/wrappers';
+import { Assertions } from '@src/assertions';
+import { ERC20API } from '@src/api';
+import { DEFAULT_ACCOUNT, DEPLOYED_TOKEN_QUANTITY, TX_DEFAULTS } from '@src/constants';
+import { ACCOUNTS } from '@src/constants/accounts';
+import { BigNumber, ether, Web3Utils } from '@src/util';
 import {
   addAuthorizationAsync,
   deployTokenAsync,
   deployVaultContract,
   deployTransferProxyContract,
   deployCoreContract
-} from '../../helpers';
+} from '@helpers/index';
 
 ChaiSetup.configure();
 const contract = require('truffle-contract');

--- a/test/integration/api/ERC20API.spec.ts
+++ b/test/integration/api/ERC20API.spec.ts
@@ -28,7 +28,7 @@ import { StandardTokenMock } from 'set-protocol-contracts';
 import { StandardTokenMockContract } from 'set-protocol-contracts';
 import { Address } from 'set-protocol-utils';
 
-import ChaiSetup from '@helpers/chaiSetup';
+import ChaiSetup from '@test/helpers/chaiSetup';
 import { CoreWrapper } from '@src/wrappers';
 import { Assertions } from '@src/assertions';
 import { ERC20API } from '@src/api';
@@ -41,7 +41,7 @@ import {
   deployVaultContract,
   deployTransferProxyContract,
   deployCoreContract
-} from '@helpers/index';
+} from '@test/helpers';
 
 ChaiSetup.configure();
 const contract = require('truffle-contract');

--- a/test/integration/api/FactoryAPI.spec.ts
+++ b/test/integration/api/FactoryAPI.spec.ts
@@ -38,7 +38,7 @@ import {
   VaultContract
 } from 'set-protocol-contracts';
 
-import ChaiSetup from '@helpers/chaiSetup';
+import ChaiSetup from '@test/helpers/chaiSetup';
 import { FactoryAPI } from '@src/api';
 import { BigNumber } from '@src/util';
 import { Assertions } from '@src/assertions';
@@ -52,7 +52,7 @@ import {
   deploySetTokenFactoryContract,
   deployTransferProxyContract,
   deployVaultContract,
-} from '@helpers/coreHelpers';
+} from '@test/helpers/coreHelpers';
 import { getFormattedLogsFromTxHash, extractNewSetTokenAddressFromLogs } from '@src/util/logs';
 import { ether } from '@src/util/units';
 import { Web3Utils } from '@src/util/Web3Utils';

--- a/test/integration/api/FactoryAPI.spec.ts
+++ b/test/integration/api/FactoryAPI.spec.ts
@@ -38,13 +38,13 @@ import {
   VaultContract
 } from 'set-protocol-contracts';
 
-import ChaiSetup from '../../helpers/chaiSetup';
-import { FactoryAPI } from '../../../src/api';
-import { BigNumber } from '../../../src/util';
-import { Assertions } from '../../../src/assertions';
-import { CoreWrapper } from '../../../src/wrappers';
-import { DEFAULT_ACCOUNT, ACCOUNTS } from '../../../src/constants/accounts';
-import { TX_DEFAULTS, ZERO } from '../../../src/constants';
+import ChaiSetup from '@helpers/chaiSetup';
+import { FactoryAPI } from '@src/api';
+import { BigNumber } from '@src/util';
+import { Assertions } from '@src/assertions';
+import { CoreWrapper } from '@src/wrappers';
+import { DEFAULT_ACCOUNT, ACCOUNTS } from '@src/constants/accounts';
+import { TX_DEFAULTS, ZERO } from '@src/constants';
 import {
   addAuthorizationAsync,
   deployCoreContract,
@@ -52,10 +52,10 @@ import {
   deploySetTokenFactoryContract,
   deployTransferProxyContract,
   deployVaultContract,
-} from '../../helpers/coreHelpers';
-import { getFormattedLogsFromTxHash, extractNewSetTokenAddressFromLogs } from '../../../src/util/logs';
-import { ether } from '../../../src/util/units';
-import { Web3Utils } from '../../../src/util/Web3Utils';
+} from '@helpers/coreHelpers';
+import { getFormattedLogsFromTxHash, extractNewSetTokenAddressFromLogs } from '@src/util/logs';
+import { ether } from '@src/util/units';
+import { Web3Utils } from '@src/util/Web3Utils';
 
 ChaiSetup.configure();
 const contract = require('truffle-contract');

--- a/test/integration/api/IssuanceAPI.spec.ts
+++ b/test/integration/api/IssuanceAPI.spec.ts
@@ -38,16 +38,16 @@ import {
   VaultContract
 } from 'set-protocol-contracts';
 
-import ChaiSetup from '../../helpers/chaiSetup';
-import { IssuanceAPI } from '../../../src/api';
-import { BigNumber } from '../../../src/util';
-import { CoreWrapper } from '../../../src/wrappers';
-import { DEFAULT_ACCOUNT, ACCOUNTS } from '../../../src/constants/accounts';
+import ChaiSetup from '@helpers/chaiSetup';
+import { IssuanceAPI } from '@src/api';
+import { BigNumber } from '@src/util';
+import { CoreWrapper } from '@src/wrappers';
+import { DEFAULT_ACCOUNT, ACCOUNTS } from '@src/constants/accounts';
 import {
   DEPLOYED_TOKEN_QUANTITY,
   TX_DEFAULTS,
   ZERO
-} from '../../../src/constants';
+} from '@src/constants';
 import {
   addAuthorizationAsync,
   approveForTransferAsync,
@@ -58,10 +58,10 @@ import {
   deployTransferProxyContract,
   deployVaultContract,
   getTokenBalances,
-} from '../../helpers/coreHelpers';
-import { Assertions } from '../../../src/assertions';
-import { ether } from '../../../src/util/units';
-import { Web3Utils } from '../../../src/util/Web3Utils';
+} from '@helpers/coreHelpers';
+import { Assertions } from '@src/assertions';
+import { ether } from '@src/util/units';
+import { Web3Utils } from '@src/util/Web3Utils';
 
 ChaiSetup.configure();
 const contract = require('truffle-contract');

--- a/test/integration/api/IssuanceAPI.spec.ts
+++ b/test/integration/api/IssuanceAPI.spec.ts
@@ -38,7 +38,7 @@ import {
   VaultContract
 } from 'set-protocol-contracts';
 
-import ChaiSetup from '@helpers/chaiSetup';
+import ChaiSetup from '@test/helpers/chaiSetup';
 import { IssuanceAPI } from '@src/api';
 import { BigNumber } from '@src/util';
 import { CoreWrapper } from '@src/wrappers';
@@ -58,7 +58,7 @@ import {
   deployTransferProxyContract,
   deployVaultContract,
   getTokenBalances,
-} from '@helpers/coreHelpers';
+} from '@test/helpers/coreHelpers';
 import { Assertions } from '@src/assertions';
 import { ether } from '@src/util/units';
 import { Web3Utils } from '@src/util/Web3Utils';

--- a/test/integration/api/OrderAPI.spec.ts
+++ b/test/integration/api/OrderAPI.spec.ts
@@ -49,14 +49,14 @@ import {
   VaultContract
 } from 'set-protocol-contracts';
 
-import { BigNumber, SignatureUtils } from '../../../src/util';
-import ChaiSetup from '../../helpers/chaiSetup';
-import { CoreWrapper } from '../../../src/wrappers';
-import { DEFAULT_ACCOUNT, ACCOUNTS } from '../../../src/constants/accounts';
-import { OrderAPI } from '../../../src/api';
-import { ZERO } from '../../../src/constants';
-import { Assertions } from '../../../src/assertions';
-import { ether, Web3Utils, generateFutureTimestamp, calculatePartialAmount } from '../../../src/util';
+import { BigNumber, SignatureUtils } from '@src/util';
+import ChaiSetup from '@helpers/chaiSetup';
+import { CoreWrapper } from '@src/wrappers';
+import { DEFAULT_ACCOUNT, ACCOUNTS } from '@src/constants/accounts';
+import { OrderAPI } from '@src/api';
+import { ZERO } from '@src/constants';
+import { Assertions } from '@src/assertions';
+import { ether, Web3Utils, generateFutureTimestamp, calculatePartialAmount } from '@src/util';
 import {
   addAuthorizationAsync,
   approveForTransferAsync,
@@ -67,8 +67,8 @@ import {
   deploySetTokenFactoryContract,
   deployTransferProxyContract,
   deployVaultContract,
-} from '../../helpers/coreHelpers';
-import { deployTakerWalletWrapperContract, deployZeroExExchangeWrapperContract } from '../../helpers/exchangeHelpers';
+} from '@helpers/coreHelpers';
+import { deployTakerWalletWrapperContract, deployZeroExExchangeWrapperContract } from '@helpers/exchangeHelpers';
 
 ChaiSetup.configure();
 const { expect } = chai;

--- a/test/integration/api/OrderAPI.spec.ts
+++ b/test/integration/api/OrderAPI.spec.ts
@@ -50,7 +50,7 @@ import {
 } from 'set-protocol-contracts';
 
 import { BigNumber, SignatureUtils } from '@src/util';
-import ChaiSetup from '@helpers/chaiSetup';
+import ChaiSetup from '@test/helpers/chaiSetup';
 import { CoreWrapper } from '@src/wrappers';
 import { DEFAULT_ACCOUNT, ACCOUNTS } from '@src/constants/accounts';
 import { OrderAPI } from '@src/api';
@@ -67,8 +67,8 @@ import {
   deploySetTokenFactoryContract,
   deployTransferProxyContract,
   deployVaultContract,
-} from '@helpers/coreHelpers';
-import { deployTakerWalletWrapperContract, deployZeroExExchangeWrapperContract } from '@helpers/exchangeHelpers';
+} from '@test/helpers/coreHelpers';
+import { deployTakerWalletWrapperContract, deployZeroExExchangeWrapperContract } from '@test/helpers/exchangeHelpers';
 
 ChaiSetup.configure();
 const { expect } = chai;

--- a/test/integration/api/SetTokenAPI.spec.ts
+++ b/test/integration/api/SetTokenAPI.spec.ts
@@ -48,7 +48,7 @@ import {
   deployVaultContract,
   deployTokensAsync,
   deployTransferProxyContract
-} from '@helpers/index';
+} from '@test/helpers';
 import { SetDetails } from '@src/types/common';
 
 const chaiBigNumber = require('chai-bignumber');

--- a/test/integration/api/SetTokenAPI.spec.ts
+++ b/test/integration/api/SetTokenAPI.spec.ts
@@ -34,11 +34,11 @@ import {
 } from 'set-protocol-contracts';
 import { Address } from 'set-protocol-utils';
 
-import { SetTokenAPI } from '../../../src/api';
-import { DEFAULT_ACCOUNT, TX_DEFAULTS } from '../../../src/constants';
-import { BigNumber, ether, Web3Utils } from '../../../src/util';
-import { Assertions } from '../../../src/assertions';
-import { CoreWrapper } from '../../../src/wrappers';
+import { SetTokenAPI } from '@src/api';
+import { DEFAULT_ACCOUNT, TX_DEFAULTS } from '@src/constants';
+import { BigNumber, ether, Web3Utils } from '@src/util';
+import { Assertions } from '@src/assertions';
+import { CoreWrapper } from '@src/wrappers';
 import {
   addAuthorizationAsync,
   approveForTransferAsync,
@@ -48,8 +48,8 @@ import {
   deployVaultContract,
   deployTokensAsync,
   deployTransferProxyContract
-} from '../../helpers';
-import { SetDetails } from '../../../src/types/common';
+} from '@helpers/index';
+import { SetDetails } from '@src/types/common';
 
 const chaiBigNumber = require('chai-bignumber');
 chai.use(chaiBigNumber(BigNumber));

--- a/test/testSets.ts
+++ b/test/testSets.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from '../src/util';
+import { BigNumber } from '@src/util';
 
 export interface Token {
   name: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
         "node_modules/@0xproject/typescript-typings/types/*",
         "node_modules/*",
         "src/types/*",
-      ]
+      ],
+      "@src/*": [ "src/*" ],
     },
     "declarationDir": "dist/types"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
         "src/types/*",
       ],
       "@src/*": [ "src/*" ],
-      "@helpers/*": [ "test/helpers/*" ],
+      "@test/*": [ "test/*" ],
     },
     "declarationDir": "dist/types"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
         "src/types/*",
       ],
       "@src/*": [ "src/*" ],
+      "@helpers/*": [ "test/helpers/*" ],
     },
     "declarationDir": "dist/types"
   },


### PR DESCRIPTION
In setprotocol.js, since jest can run typescript files - we don't need to add `module-alias`. Instead, we just need to add a `"moduleNameMapper"` property to the jest config.