### PR TITLE
Yarn: Fix vulnerable `merge` package

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2570,7 +2570,7 @@ exec-sh@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.2.tgz#2a5e7ffcbd7d0ba2755bdecb16e5a427dfbdec36"
   dependencies:
-    merge "^1.2.0"
+    merge "^1.2.1"
 
 execa@^0.7.0:
   version "0.7.0"
@@ -4533,9 +4533,9 @@ merge-stream@^1.0.1:
   dependencies:
     readable-stream "^2.0.1"
 
-merge@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
+merge@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
 
 merkle-patricia-tree@^2.1.2:
   version "2.3.2"


### PR DESCRIPTION
# Changelog
Upgrades vulnerable version of `merge` to patched version.
[Link to security alert](https://github.com/SetProtocol/setprotocol.js/network/alert/package-lock.json/merge/open)
<img width="995" alt="screen shot 2018-11-03 at 2 35 52 pm" src="https://user-images.githubusercontent.com/4149515/47957580-ddca7200-df75-11e8-95f1-e69439d54783.png">

### Notes
`merge` is a nested child dependency of `jest`. Upgrading `jest` to the latest version unfortunately does not upgrade `merge` to a version `>=1.2.1`.

**Caveats**: When running `rm -rf node_modules`, `merge` will be reverted back to the vulnerable `^1.2.0` version.