### PR TITLE
Improve PayableExchange issue Errors

### DIFF
--- a/src/SetProtocol.ts
+++ b/src/SetProtocol.ts
@@ -147,14 +147,12 @@ class SetProtocol {
     this.rebalancingManager = new RebalancingManagerAPI(this.web3);
     this.exchangeIssue = new ExchangeIssueAPI(this.web3, assertions, config.exchangeIssueModuleAddress);
 
-    if (config.payableExchangeIssue && config.wrappedEtherAddress) {
-      this.payableExchangeIssue = new PayableExchangeIssueAPI(
-        this.web3,
-        assertions,
-        config.payableExchangeIssue,
-        config.wrappedEtherAddress,
-      );
-    }
+    this.payableExchangeIssue = new PayableExchangeIssueAPI(
+      this.web3,
+      assertions,
+      config.payableExchangeIssue,
+      config.wrappedEtherAddress,
+    );
   }
 
   /**

--- a/src/api/PayableExchangeIssueAPI.ts
+++ b/src/api/PayableExchangeIssueAPI.ts
@@ -81,7 +81,7 @@ export class PayableExchangeIssueAPI {
       rebalancingSetAddress,
       exchangeIssueParams,
       orders,
-      txOpts.from,
+      txOpts,
     );
     await this.assertExchangeIssueParams(rebalancingSetAddress, exchangeIssueParams);
 
@@ -101,12 +101,12 @@ export class PayableExchangeIssueAPI {
     rebalancingSetAddress: Address,
     exchangeIssueParams: ExchangeIssueParams,
     orders: (KyberTrade | ZeroExSignedFillOrder)[],
-    transactionCaller: Address,
+    txOpts: Tx,
   ) {
     const { setAddress, paymentToken } = exchangeIssueParams;
 
-
-    this.assert.schema.isValidAddress('txOpts.from', transactionCaller);
+    this.assert.common.isNotUndefined(txOpts.value, exchangeIssueErrors.ETHER_VALUE_NOT_UNDEFINED());
+    this.assert.schema.isValidAddress('txOpts.from', txOpts.from);
     this.assert.schema.isValidAddress('rebalancingSetAddress', rebalancingSetAddress);
     this.assert.common.isNotEmptyArray(orders, coreAPIErrors.EMPTY_ARRAY('orders'));
 
@@ -126,10 +126,10 @@ export class PayableExchangeIssueAPI {
       exchangeIssueErrors.PAYMENT_TOKEN_NOT_WETH(paymentToken, this.wrappedEther)
     );
 
-    // await this.assert.order.assertExchangeIssueOrdersValidity(
-    //   exchangeIssueParams,
-    //   orders,
-    // );
+    await this.assert.order.assertExchangeIssueOrdersValidity(
+      exchangeIssueParams,
+      orders,
+    );
   }
 
   private async assertExchangeIssueParams(

--- a/src/assertions/CommonAssertions.ts
+++ b/src/assertions/CommonAssertions.ts
@@ -44,6 +44,12 @@ export class CommonAssertions {
     }
   }
 
+  public isNotUndefined(value: any, errorMessage: string) {
+    if (!value) {
+      throw new Error(errorMessage);
+    }
+  }
+
   public isNotEmptyArray(array: any[], errorMessage: string) {
     if (array.length == 0) {
       throw new Error(errorMessage);

--- a/src/assertions/OrderAssertions.ts
+++ b/src/assertions/OrderAssertions.ts
@@ -296,6 +296,12 @@ export class OrderAssertions {
       );
 
       const normalizedTokenAddress = component.toLowerCase();
+
+      this.commonAssertions.isNotUndefined(
+        componentAmountsFromLiquidity[normalizedTokenAddress],
+        orderErrors.INSUFFIENT_LIQUIDITY_FOR_REQUIRED_COMPONENT(normalizedTokenAddress),
+      );
+
       this.commonAssertions.isEqualBigNumber(
         componentAmountsFromLiquidity[normalizedTokenAddress],
         requiredComponentAmountForFillQuantity,

--- a/src/errors/exchangeIssueErrors.ts
+++ b/src/errors/exchangeIssueErrors.ts
@@ -22,4 +22,6 @@ export const exchangeIssueErrors = {
     `not the expected wrapped ether token at ${wethAddress}`,
   ISSUING_SET_NOT_BASE_SET: (setAddress: string, currentSet: string) => `Set token at ${setAddress} is ` +
     `not the expected rebalancing set token current Set at ${currentSet}`,
+  ETHER_VALUE_NOT_UNDEFINED: () =>
+    `Ether value should not be undefined`,
 };

--- a/src/errors/orderErrors.ts
+++ b/src/errors/orderErrors.ts
@@ -23,6 +23,9 @@ export const orderErrors = {
   FILL_EXCEEDS_AVAILABLE: (availableFillAmount: BigNumber) =>
     `The fill quantity supplied exceeds the amount available to fill. Remaining fillable quantity: ` +
     `${availableFillAmount.toString()}.`,
+  INSUFFIENT_LIQUIDITY_FOR_REQUIRED_COMPONENT: (
+    component: string,
+  ) => `Token ${component} is unrepresented in the liquidity orders.`,
   INSUFFICIENT_COMPONENT_AMOUNT_FROM_LIQUIDITY: (
     component: string,
     componentAmount: BigNumber,

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -106,8 +106,8 @@ export interface SetProtocolConfig {
   exchangeIssueModuleAddress: Address;
   issuanceOrderModuleAddress: Address;
   rebalancingTokenIssuanceModule: Address;
-  payableExchangeIssue?: Address;
-  wrappedEtherAddress?: Address;
+  payableExchangeIssue: Address;
+  wrappedEtherAddress: Address;
 }
 
 export interface SystemAuthorizableState {

--- a/test/integration/api/PayableExchangeIssueAPI.spec.ts
+++ b/test/integration/api/PayableExchangeIssueAPI.spec.ts
@@ -157,7 +157,9 @@ describe('PayableExchangeIssueAPI', () => {
     let subjectExchangeIssueData: ExchangeIssueParams;
     let subjectExchangeOrder: (KyberTrade | ZeroExSignedFillOrder)[];
     let subjectCaller: Address;
-    let subjectEther: BigNumber;
+    let etherValue: BigNumber;
+
+    let subjectEther: string;
 
     let zeroExOrderMaker: Address;
 
@@ -206,13 +208,13 @@ describe('PayableExchangeIssueAPI', () => {
         ONE_DAY_IN_SECONDS,
       );
 
-      subjectEther = new BigNumber(10 ** 10);
+      etherValue = new BigNumber(10 ** 10);
 
       // Generate exchange issue data
       exchangeIssueSetAddress = baseSetToken.address;
       exchangeIssueQuantity = new BigNumber(10 ** 10);
       exchangeIssuePaymentToken = wrappedEtherMock.address;
-      exchangeIssuePaymentTokenAmount = subjectEther;
+      exchangeIssuePaymentTokenAmount = etherValue;
       exchangeIssueRequiredComponents = componentAddresses;
       exchangeIssueRequiredComponentAmounts = componentUnits.map(
         unit => unit.mul(exchangeIssueQuantity).div(baseSetNaturalUnit)
@@ -256,6 +258,8 @@ describe('PayableExchangeIssueAPI', () => {
       rebalancingSetQuantity = exchangeIssueQuantity.mul(DEFAULT_REBALANCING_NATURAL_UNIT).div(rebalancingUnitShares);
 
       subjectCaller = ACCOUNTS[1].address;
+
+      subjectEther = etherValue.toString();
     });
 
     async function subject(): Promise<string> {
@@ -263,7 +267,7 @@ describe('PayableExchangeIssueAPI', () => {
         subjectRebalancingSetAddress,
         subjectExchangeIssueData,
         subjectExchangeOrder,
-        { from: subjectCaller, value: subjectEther.toString() }
+        { from: subjectCaller, value: subjectEther }
       );
     }
 
@@ -301,6 +305,18 @@ describe('PayableExchangeIssueAPI', () => {
       test('throws', async () => {
         return expect(subject()).to.be.rejectedWith(
           `Set token at ${notBaseSet} is not the expected rebalancing set token current Set at ${baseSetToken.address}`
+        );
+      });
+    });
+
+    describe.only('when an empty value is passed in', async () => {
+      beforeEach(async () => {
+        subjectEther = undefined;
+      });
+
+      test('throws', async () => {
+        return expect(subject()).to.be.rejectedWith(
+           `Ether value should not be undefined`
         );
       });
     });

--- a/test/integration/api/RebalancingAPI.spec.ts
+++ b/test/integration/api/RebalancingAPI.spec.ts
@@ -147,6 +147,8 @@ describe('RebalancingAPI', () => {
       issuanceOrderModuleAddress: NULL_ADDRESS,
       rebalancingTokenIssuanceModule: rebalanceIssuanceModule.address,
       exchangeIssueModuleAddress: NULL_ADDRESS,
+      payableExchangeIssue: NULL_ADDRESS,
+      wrappedEtherAddress: NULL_ADDRESS,
     };
 
     await addModuleAsync(core, rebalanceIssuanceModule.address);

--- a/test/integration/api/SystemAPI.spec.ts
+++ b/test/integration/api/SystemAPI.spec.ts
@@ -123,6 +123,8 @@ describe('SystemAPI', () => {
       rebalancingSetTokenFactoryAddress: rebalancingSetTokenFactory.address,
       rebalancingTokenIssuanceModule: rebalancingTokenIssuanceModule.address,
       exchangeIssueModuleAddress: NULL_ADDRESS,
+      payableExchangeIssue: NULL_ADDRESS,
+      wrappedEtherAddress: NULL_ADDRESS,
     };
 
     systemAPI = new SystemAPI(web3, coreWrapper, setProtocolConfig);


### PR DESCRIPTION
- Add check for value in PayableExchangeIssue
- Reverts if requiredComponents is not represented in liquidity orders
- Make payableExchangeIssue and wrappedEther addresses mandatory