### PR TITLE
Bump version to rc11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setprotocol.js",
-  "version": "1.2.2-rc10",
+  "version": "1.2.2-rc11",
   "description": "A javascript library for interacting with the Set protocol",
   "keywords": [
     "setProtocol.js",


### PR DESCRIPTION
Previous package had `src/schemas/SchemaValidator` published in the package instead of `schemaValidator` because OSX didn't properly detect the change in file name during git commit